### PR TITLE
Added hoverable tooltips for check-in form and about page text

### DIFF
--- a/shopsafe-frontend/src/app/app.module.ts
+++ b/shopsafe-frontend/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { CheckInModalComponent } from './components/check-in-modal/check-in-moda
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [
@@ -35,7 +36,8 @@ import { MatIconModule } from '@angular/material/icon';
     BrowserAnimationsModule,
     MatDialogModule,
     MatSliderModule,
-    MatIconModule
+    MatIconModule,
+    MatTooltipModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/shopsafe-frontend/src/app/components/about/about.component.css
+++ b/shopsafe-frontend/src/app/components/about/about.component.css
@@ -2,3 +2,15 @@
     padding-bottom: 20px;
     text-align: center;
 }
+
+#about .box p {
+    text-align: justify;
+}
+
+#about .box p:hover {
+    color: rgb(255, 135, 86, 0.7);
+}
+
+#about .section {
+    padding-top: 20px;
+}

--- a/shopsafe-frontend/src/app/components/about/about.component.html
+++ b/shopsafe-frontend/src/app/components/about/about.component.html
@@ -4,6 +4,37 @@
             <h1>ABOUT</h1>
             <p>Learn more about this tool, its developers, and its usages.</p>
         </div>
+        <div class="section">
+            <h2>Philosophy</h2>
+            <div class="box">
+                <p>
+                    ShopSafe is a tool designed to help ease the decision fatigue that comes with 
+                    deciding what is the safest place to go shopping during COVID-19. The purpose 
+                    of this tool is to provide a crowdsourced method of evaluating how safe a 
+                    grocery store is to go to in order to provide a more informed shopping experience.
+                </p>
+            </div>
+        </div>
+        <div class="section">
+            <h2>Usage</h2>
+            <div class="box">
+                <p>
+                    This tool is meant to be used in concurrence with good judgement and awareness 
+                    of local regulations. The ShopSafe Score is calculated using the check-in and 
+                    county statistics based on user input and the New York Times COVID-19 dataset. 
+                    This is in no means a deterministic metric but rather a decision-making tool.
+                </p>
+            </div>
+        </div>
+        <div class="section">
+            <h2>Creators</h2>
+            <div class="box">
+                <p>
+                    This application is created by Gabriel Stewart, Raul Palomo, and Carol Li under 
+                    their 2020 Google Internship. 
+                </p>
+            </div>
+        </div>
         
     </div>
 </div>

--- a/shopsafe-frontend/src/app/components/about/about.component.html
+++ b/shopsafe-frontend/src/app/components/about/about.component.html
@@ -10,8 +10,9 @@
                 <p>
                     ShopSafe is a tool designed to help ease the decision fatigue that comes with 
                     deciding what is the safest place to go shopping during COVID-19. The purpose 
-                    of this tool is to provide a crowdsourced method of evaluating how safe a 
-                    grocery store is to go to in order to provide a more informed shopping experience.
+                    of this tool is to provide a crowdsourced method of evaluating the safety of 
+                    a grocery store to give users a more informed shopping experience.
+   
                 </p>
             </div>
         </div>
@@ -22,7 +23,7 @@
                     This tool is meant to be used in concurrence with good judgement and awareness 
                     of local regulations. The ShopSafe Score is calculated using the check-in and 
                     county statistics based on user input and the New York Times COVID-19 dataset. 
-                    This is in no means a deterministic metric but rather a decision-making tool.
+                    This is not a deterministic metric but rather a decision-making tool.
                 </p>
             </div>
         </div>
@@ -30,8 +31,9 @@
             <h2>Creators</h2>
             <div class="box">
                 <p>
-                    This application is created by Gabriel Stewart, Raul Palomo, and Carol Li under 
-                    their 2020 Google Internship. 
+                    This application is created by <a href="mailto:gabrielstewart@google.com">Gabriel Stewart</a>, 
+                    <a href="mailto:raulpalomo@google.com">Raul Palomo</a>, and <a href="mailto:caroljli@google.com">Carol Li</a> 
+                    under their 2020 Google Internship. 
                 </p>
             </div>
         </div>

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
@@ -44,3 +44,7 @@
 #check-in-modal #submit-check-in-button:hover {
     background: rgba(104, 187, 207, 0.3);
 }
+
+#check-in-modal .tooltip {
+    font-size: 13px !important;
+}

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
@@ -45,6 +45,6 @@
     background: rgba(104, 187, 207, 0.3);
 }
 
-#check-in-modal .tooltip {
+#check-in-modal .mat-tooltip {
     font-size: 13px !important;
 }

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.css
@@ -2,6 +2,11 @@
     text-transform: uppercase;
 }
 
+#check-in-modal p {
+    font-size: 13px;
+    text-align: center;
+}
+
 #check-in-modal h2.title-text {
     text-align: center;
 }

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
@@ -43,7 +43,9 @@
                 <a 
                 matTooltip="How clean is the store overall? Are the shared carts, 
                             baskets, and surfaces sanitized? 1 indicates poor hygiene 
-                            (bad) and 10 indicates good hygiene (good).">
+                            (bad) and 10 indicates good hygiene (good)."
+                matTooltipClass="tooltip"
+                >
                     <i class="far fa-question-circle"></i>
                 </a>
             </h2>

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
@@ -6,9 +6,9 @@
             <h2 class="left-text">
                 Busy &nbsp; 
                 <a 
-                matTooltip="How busy the store is, in terms of the crowd inside the store 
-                            (ie. is there enough space to maintain 6 feet of distance? 1 indicates very busy (bad), 
-                            and 10 indicates not busy at all (good).">
+                matTooltip="How crowded is it inside the store? Essentially, is there 
+                            enough space to social distance, maintain 6 feet? 1 indicates 
+                            very busy (bad), and 10 indicates not busy at all (good)">
                     <i class="far fa-question-circle"></i>
                 </a>
             </h2>
@@ -24,8 +24,8 @@
             <h2 class="left-text">
                 Line &nbsp; 
                 <a 
-                matTooltip="How long the line is to get into the store from the outside. 
-                            1 indicates very long (bad), and 10 indicates not long at all (good).">
+                matTooltip="How long is the line to get into the store from the outside?
+                            1 indicates very long (bad), and 10 indicates not long at all (good)">
                     <i class="far fa-question-circle"></i>
                 </a>
             </h2>
@@ -43,8 +43,7 @@
                 <a 
                 matTooltip="How clean is the store overall? Are the shared carts, 
                             baskets, and surfaces sanitized? 1 indicates poor hygiene 
-                            (bad) and 10 indicates good hygiene (good)."
-                matTooltipClass="tooltip"
+                            (bad), and 10 indicates good hygiene (good)"
                 >
                     <i class="far fa-question-circle"></i>
                 </a>
@@ -61,9 +60,9 @@
             <h2 class="left-text">
                 Mask &nbsp; 
                 <a 
-                matTooltip="Is the store strict on masks? Are the customers and workers 
+                matTooltip="How strict is the store with masks? Are the customers and workers 
                             wearing masks properly? 1 indicates no to little mask policy 
-                            and presence (bad) and 10 indicates excellent mask usage (good).">
+                            and presence (bad), and 10 indicates excellent mask usage (good)">
                     <i class="far fa-question-circle"></i>
                 </a>
             </h2>

--- a/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
+++ b/shopsafe-frontend/src/app/components/check-in-modal/check-in-modal.component.html
@@ -1,8 +1,17 @@
 <div id="check-in-modal">
     <h2 class="title-text">Check-In Form</h2>
+    <p>Use the sliders to input the statuses of the store to check in. High values indicates a good status, and low values indicate a bad status.</p>
     <div class="modal-content">
         <div class="option">
-            <h2 class="left-text">Busy &nbsp; <a><i class="far fa-question-circle"></i></a></h2>
+            <h2 class="left-text">
+                Busy &nbsp; 
+                <a 
+                matTooltip="How busy the store is, in terms of the crowd inside the store 
+                            (ie. is there enough space to maintain 6 feet of distance? 1 indicates very busy (bad), 
+                            and 10 indicates not busy at all (good).">
+                    <i class="far fa-question-circle"></i>
+                </a>
+            </h2>
             <mat-slider 
                 min="1" 
                 max="10" 
@@ -12,7 +21,14 @@
             ></mat-slider>
         </div>
         <div class="option">
-            <h2 class="left-text">Line &nbsp; <a><i class="far fa-question-circle"></i></a></h2>
+            <h2 class="left-text">
+                Line &nbsp; 
+                <a 
+                matTooltip="How long the line is to get into the store from the outside. 
+                            1 indicates very long (bad), and 10 indicates not long at all (good).">
+                    <i class="far fa-question-circle"></i>
+                </a>
+            </h2>
             <mat-slider 
                 min="1" 
                 max="10" 
@@ -22,7 +38,15 @@
             ></mat-slider>
         </div>
         <div class="option">
-            <h2 class="left-text">Hygiene &nbsp; <a><i class="far fa-question-circle"></i></a></h2>
+            <h2 class="left-text">
+                Hygiene &nbsp; 
+                <a 
+                matTooltip="How clean is the store overall? Are the shared carts, 
+                            baskets, and surfaces sanitized? 1 indicates poor hygiene 
+                            (bad) and 10 indicates good hygiene (good).">
+                    <i class="far fa-question-circle"></i>
+                </a>
+            </h2>
             <mat-slider 
                 min="1" 
                 max="10" 
@@ -32,7 +56,15 @@
             ></mat-slider>
         </div>
         <div class="option">
-            <h2 class="left-text">Masks &nbsp; <a><i class="far fa-question-circle"></i></a></h2>
+            <h2 class="left-text">
+                Mask &nbsp; 
+                <a 
+                matTooltip="Is the store strict on masks? Are the customers and workers 
+                            wearing masks properly? 1 indicates no to little mask policy 
+                            and presence (bad) and 10 indicates excellent mask usage (good).">
+                    <i class="far fa-question-circle"></i>
+                </a>
+            </h2>
             <mat-slider 
                 min="1" 
                 max="10" 

--- a/shopsafe-frontend/src/app/components/landing/landing.component.css
+++ b/shopsafe-frontend/src/app/components/landing/landing.component.css
@@ -15,8 +15,9 @@
 }
 
 #landing .input-container .search-icon {
-    padding: 15px 50px 15px;
-    color: #4A4A4A;
+    padding: 12px 13px 10px;
+    position: absolute;
+    color: rgba(196, 196, 196);
 }
 
 #landing .input-field {

--- a/shopsafe-frontend/src/app/components/landing/landing.component.html
+++ b/shopsafe-frontend/src/app/components/landing/landing.component.html
@@ -8,7 +8,7 @@
         </div>
         <form>
             <div class="input-container">
-                <!-- <i class="fas fa-search search-icon"></i> -->
+                <mat-icon class="search-icon">search</mat-icon>
                 <input class="input-field" type="text" placeholder="ENTER YOUR LOCATION TO FIND NEARBY GROCERY STORES" name="search">
             </div>
         </form>

--- a/shopsafe-frontend/src/app/components/store/store.component.ts
+++ b/shopsafe-frontend/src/app/components/store/store.component.ts
@@ -23,8 +23,8 @@ export class StoreComponent implements OnInit {
     const dialogConfig = new MatDialogConfig();
 
     dialogConfig.id = "check-in-modal";
-    dialogConfig.height = "470px";
-    dialogConfig.width = "454px";
+    dialogConfig.height = "500px";
+    dialogConfig.width = "460px";
     const modalDialog = this.matDialog.open(CheckInModalComponent, dialogConfig);
   }
 

--- a/shopsafe-frontend/src/styles.css
+++ b/shopsafe-frontend/src/styles.css
@@ -1,4 +1,5 @@
-/* You can add global styles to this file, and also import other style files */
+@import url( 'https://fonts.googleapis.com/css?family=Roboto:400,700|Material+Icons');
+
 @font-face {
   font-family: 'Avenir Next';
   src: url('./assets/fonts/AvenirNext-Regular.ttf') format('truetype');
@@ -36,6 +37,10 @@
   font-family: "Avenir Next", sans-serif !important;
   scroll-behavior: smooth;
   box-sizing: border-box;
+}
+
+mat-icon {
+  font-family: 'Material Icons' !important;
 }
 
 .segment {


### PR DESCRIPTION
* Added hoverable tooltips that show aid text
* Added about page text that focuses on hover
* Specific text can be found [here](https://docs.google.com/document/d/1EnzqvVZ-XiFn8UyZmRgdG7Fkh2icn5R2FMvLoZ3oUjk/edit#heading=h.r97p387ih2of).
* Fixed search bar icon bug

**Screenshots:**
![image](https://user-images.githubusercontent.com/52721221/86157760-daceae80-bad5-11ea-8ede-7201f93b968c.png)
* Hoverable tooltip
![image](https://user-images.githubusercontent.com/52721221/86157792-e28e5300-bad5-11ea-8223-9bf6308a2b70.png)
* About page text
* @glstewart17 @Raulp8 check the about page wording specifically -- can be changed however you guys want it to, and we can also add links to emails (ie. mailto:) if you want to
![image](https://user-images.githubusercontent.com/52721221/86159998-2898e600-bad9-11ea-85da-ebbfcd7e1c6a.png)
* There's a search icon now!